### PR TITLE
Planck sims

### DIFF
--- a/actsims/simgen.py
+++ b/actsims/simgen.py
@@ -34,6 +34,7 @@ class SimGen(object):
         self.noise_gen  = noise.NoiseGen(version=version,model=model,ncache=max_cached,verbose=False)
         self.signal_gen = signal.SignalGen(cmb_type=cmb_type, dobeam=dobeam, add_foregrounds=add_foregrounds, apply_window=apply_window, max_cached=max_cached, model=model)
         self.default_geometries = {}
+        self.model = model
         
         if (extract_region is not None) or (extract_region_shape is not None):
             self._refoot = True
@@ -95,7 +96,17 @@ class SimGen(object):
         afreqs = self.noise_gen.dm.array_freqs[array]
         signals = []
         for afreq in afreqs:
-            imap = self.get_signal(season, patch, array, afreq.split('_')[1], sim_num, save_alm=save_alm, save_map=save_map, set_idx=set_idx,oshape=shape,owcs=wcs)
+
+            # This could be improved
+            if self.model=='act_mr3': pfreq = afreq.split('_')[1] 
+            elif self.model=='planck_hybrid': 
+                pfreq = afreq
+                assert season is None
+                season = "planck"
+                patch = "planck"
+                array = "planck"
+
+            imap = self.get_signal(season, patch, array, pfreq, sim_num, save_alm=save_alm, save_map=save_map, set_idx=set_idx,oshape=shape,owcs=wcs)
             signals.append(imap)
         owcs = imap.wcs
         # (nfreqs,npol,Ny,Nx)

--- a/bin/inpaint_mr3.py
+++ b/bin/inpaint_mr3.py
@@ -12,7 +12,7 @@ apatch = sys.argv[1]
 
 out_dir = "/scratch/r/rbond/msyriac/data/depot/actsims/inpainted/"
 
-plot_img = lambda x,y: io.plot_img(x,os.environ['WORK']+"/"+y)
+plot_img = lambda x,y: io.plot_img(x,os.environ['WORK']+"/new_mr3f/"+y)
 noise_pix = 60
 cmb_theory_fn = lambda s,l: cosmology.default_theory().lCl(s,l)
 hole_radius = 9.
@@ -44,7 +44,7 @@ def plot_cutout(nsplits,cutout,ivars,tag="",skip_plots=False):
         if not(skip_plots): plot_img(retvars[s,0],"ivars_filled_%s.png" % iname)
     return retvars
 
-ras,decs = np.loadtxt("inputParams/mr3_cut_sources.txt",unpack=True)
+ras,decs = np.loadtxt("/home/r/rbond/sigurdkn/project/actpol/maps/mr3f_20190502/cat_bright_tot.txt",unpack=True,usecols=[0,1])
 
 dm = sints.ACTmr3(calibrated=False)
 
@@ -52,6 +52,7 @@ for season in dm.seasons:
     for patch in dm.patches:
         if patch!=apatch: continue
         for array in dm.arrays:
+            if array!="pa3_f090": continue # !!!
             try: 
                 splits = dm.get_splits(season,patch,array,ncomp=None,srcfree=True)[0]
                 print("Found %s %s %s" % (season,patch,array))
@@ -77,7 +78,7 @@ for season in dm.seasons:
             # Save ivar map
             #....
             for i in range(nsplits):
-                fname = out_dir+os.path.basename(dm.get_split_ivar_fname(season,patch,array,i)).replace(".fits","_inpainted.fits")
+                fname = out_dir+os.path.basename(dm.get_split_ivar_fname(season,patch,array,i))
                 enmap.write_map(fname,ivars[i])
             
             # Inpaint each split
@@ -117,6 +118,6 @@ for season in dm.seasons:
             #....
 
             for i in range(nsplits):
-                fname = out_dir+os.path.basename(dm.get_split_fname(season,patch,array,i,srcfree=True)).replace(".fits","_inpainted.fits")
+                fname = out_dir+os.path.basename(dm.get_split_fname(season,patch,array,i,srcfree=True))
                 enmap.write_map(fname,inpainted[i])
                 

--- a/bin/inspect_mr3.py
+++ b/bin/inspect_mr3.py
@@ -1,0 +1,104 @@
+from __future__ import print_function
+import matplotlib
+matplotlib.use('Agg')
+from orphics import maps,io,cosmology,pixcov
+from pixell import enmap,reproject
+import numpy as np
+import os,sys
+import soapack.interfaces as sints
+from enlib import bench
+from actsims import noise
+
+# apatch = sys.argv[1]
+# season = sys.argv[2]
+# array = sys.argv[3]
+
+dm = sints.ACTmr3(calibrated=False)
+
+for season in ['s13','s14','s15']:
+    for apatch in ['deep1','deep5','deep6','deep8','deep56','boss']:
+        for array in ['pa1_f150','pa2_f150','pa3_f150','pa3_f090']:
+
+            fname = "%s_%s_%s" % (season,apatch,array)
+            try:
+                splits = dm.get_splits(season=season,patch=apatch,arrays=[array],ncomp=1,srcfree=False)[0,:,0,...]
+            except:
+                continue
+            ivars = dm.get_splits_ivar(season=season,patch=apatch,arrays=[array],ncomp=None)[0,:,0,...]
+            cmap,_ = noise.get_coadd(splits,ivars,axis=0)
+
+            io.hplot(cmap,os.environ['WORK']+"/new_mr3f/coadd_%s.png" % fname,min=-300,max=600,grid=True)
+            splits = dm.get_splits(season=season,patch=apatch,arrays=[array],ncomp=1,srcfree=True)[0,:,0,...]
+            cmap,_ = noise.get_coadd(splits,ivars,axis=0)
+            io.hplot(cmap,os.environ['WORK']+"/new_mr3f/coadd_srcfree_%s.png" % fname,min=-300,max=600,grid=True)
+sys.exit()
+
+out_dir = "/scratch/r/rbond/msyriac/data/depot/actsims/inpainted/"
+
+plot_img = lambda x,y,**kwargs: io.plot_img(x,os.environ['WORK']+"/new_mr3f/"+y,cmap='gray',**kwargs)
+noise_pix = 60
+cmb_theory_fn = lambda s,l: cosmology.default_theory().lCl(s,l)
+hole_radius = 9.
+res = np.deg2rad(0.5/60.)
+
+def plot_cutout(nsplits,cutout,pcutout,ivars,tag="",skip_plots=False):
+    pols = ['I','Q','U']
+    retvars = ivars.copy()
+    for s in range(nsplits):
+        if np.std(cutout[s])<1e-3: 
+            print("Skipping split %d as it seems empty" % s)
+            continue
+        iname = "%s%s_%s_%s_split_%d_%d" % (tag,season,patch,array,s,sid)
+        if not(skip_plots): plot_img(ivars[s,0],"ivars_%s.png" % iname)
+        for p in range(3):
+            pol = pols[p]
+            sname = "%s%s_%s_%s_split_%d_%s_%d" % (tag,season,patch,array,s,pol,sid)
+            if not(skip_plots): 
+                plot_img(cutout[s,p],"cutout_%s.png" % sname,lim=1000)
+                plot_img(pcutout[s,p],"pcutout_%s.png" % sname,lim=1000)
+            masked = cutout[s,p].copy()
+            modrmap = masked.modrmap()
+            cutradius = np.deg2rad(hole_radius/60.)
+            masked[modrmap<cutradius] = np.nan
+            #if not(skip_plots): plot_img(masked,"masked_%s.png" % sname)
+        masked = ivars[s,0].copy()
+        masked[modrmap<cutradius] = np.nan
+        iname = "%s%s_%s_%s_split_%d_%d" % (tag,season,patch,array,s,sid)
+        #if not(skip_plots): plot_img(masked,"ivars_masked_%s.png" % iname)
+        retvars[s,0,modrmap<cutradius] = retvars[s,0,modrmap>=cutradius].mean()
+        #if not(skip_plots): plot_img(retvars[s,0],"ivars_filled_%s.png" % iname)
+    return retvars
+
+ras,decs = np.loadtxt("inputParams/mr3_cut_sources.txt",unpack=True)
+
+dm = sints.ACTmr3(calibrated=False)
+
+for season in dm.seasons:
+    if season == "s16": continue
+    for patch in dm.patches:
+        if patch!=apatch: continue
+        for array in dm.arrays:
+            try: 
+                splits = dm.get_splits(season,patch,array,ncomp=None,srcfree=True)[0]
+                psplits = dm.get_splits(season,patch,array,ncomp=None,srcfree=False)[0]
+                print("Found %s %s %s" % (season,patch,array))
+            except: 
+                continue
+            ivars = dm.get_splits_ivar(season,patch,array,ncomp=None)[0]
+            wcs = ivars.wcs
+            nsplits = ivars.shape[0]
+
+            ids = []
+            sel_ivars = []
+            for sid,(ra,dec) in enumerate(zip(ras,decs)):
+                cutout = reproject.cutout(splits, ra=np.deg2rad(ra), dec=np.deg2rad(dec), pad=1, corner=False,npix=noise_pix)
+                pcutout = reproject.cutout(psplits, ra=np.deg2rad(ra), dec=np.deg2rad(dec), pad=1, corner=False,npix=noise_pix)
+                if (cutout is not None): 
+                    sel_ivar = reproject.cutout(ivars, ra=np.deg2rad(ra), dec=np.deg2rad(dec), pad=1, corner=False,npix=noise_pix,return_slice=True)
+                    cut_ivar = ivars[sel_ivar]
+                    retv = plot_cutout(nsplits,cutout,pcutout,cut_ivar,skip_plots=False)
+                    ivars[sel_ivar] = retv
+                    ids.append(sid)
+                    sel_ivars.append(sel_ivar)
+
+

--- a/bin/make_covsqrt.py
+++ b/bin/make_covsqrt.py
@@ -37,6 +37,7 @@ parser.add_argument("-r", "--radial-fit-annulus",     type=int,  default=20,help
 parser.add_argument("-d", "--dfact",     type=int,  default=8,help="Downsample factor.")
 parser.add_argument("-a", "--aminusc", action='store_true',help='Whether to use the auto minus cross estimator.')
 parser.add_argument("--no-write", action='store_true',help='Do not write any FITS to disk.')
+parser.add_argument("--calibrated", action='store_true',help='Apply default calibration factors to arrays.')
 parser.add_argument("--no-off", action='store_true',help='Null the off-diagonals.')
 parser.add_argument("--no-prewhiten", action='store_true',help='Do not prewhiten spectra before smoothing. Use this flag for Planck.')
 parser.add_argument("--overwrite", action='store_true',help='Overwrite an existing version.')
@@ -73,7 +74,7 @@ mask = sints.get_act_mr3_crosslinked_mask(mask_patch,
                                           pad=args.mask_pad)
 
 if args.debug: noise.plot(pout+"_mask",mask,grid=True)
-dm = sints.models[args.model](region=mask)
+dm = sints.models[args.model](region=mask,calibrated=args.calibrated)
 
 # Get a NoiseGen model
 if args.extract_mask is not None:

--- a/bin/make_masks.py
+++ b/bin/make_masks.py
@@ -13,6 +13,21 @@ binary masks from Steve, pads it a bit and then pads it
 a bit more to make it FFT friendly.
 """
 
+def mask_smoothing(inmap, N, f = 0.5):
+    import scipy
+    smoothed = scipy.ndimage.filters.gaussian_filter(inmap, N)
+    new = np.zeros(smoothed.shape)
+    new[smoothed > f] = 1.
+    smoothedagain = scipy.ndimage.filters.gaussian_filter(new, N)
+    new = enmap.enmap(smoothedagain, inmap.wcs)
+    assert np.all((inmap-new)>=0)
+    return new
+
+def get_smooth_N(patch):
+    if patch in ['deep1','deep5','deep6','deep8']:
+        return 50
+    else:
+        return 75
 
 out_version = "padded_v1"
 in_versions = {'actpol': "mr3c_20190215_pickupsub_190301",'advact': "mr3c_20190215_pickupsub_190303"}
@@ -63,4 +78,9 @@ for survey in in_versions.keys():
 
         enmap.write_map(out_path+"%s.fits" % patch,mask)
         io.hplot(enmap.downgrade(mask,8),out_path+"%s" % patch)
+
+        sN = get_smooth_N(patch)
+        smoothed = mask_smoothing(mask,sN)
+        enmap.write_map(out_path+"%s_smoothed.fits" % patch,smoothed)
+        io.hplot(enmap.downgrade(smoothed,8),out_path+"%s_smoothed" % patch)
         

--- a/submit_planck.py
+++ b/submit_planck.py
@@ -1,12 +1,12 @@
 import os,sys
 
-#arrays = ['033', '044', '070', '100', '143' ,'217', '353', '545', '857']
-#lmaxes = [3000,3000,3000,6000,6000,6000,6000,6000,6000]
+arrays = ['033', '044', '070', '100', '143' ,'217', '353', '545', '857']
+lmaxes = [3000,3000,3000,6000,6000,6000,6000,6000,6000]
 
-arrays = ['545', '857']
-lmaxes = [6000,6000]
+# arrays = ['545', '857']
+# lmaxes = [6000,6000]
 
 for array,lmax in zip(arrays,lmaxes):
     for region in ['boss', 'deep56']:
-        cmd = "mpi_niagara 1 \"python bin/make_covsqrt.py v5.2 planck_hybrid --patch %s --array %s --overwrite --no-prewhiten --mask-version padded_v1 --nsims 3 --lmax %d --nsims 5\" --walltime 00:40:00 -t 80" % (region,array,lmax)
+        cmd = "mpi_niagara 1 \"python bin/make_covsqrt.py v5.3.0 planck_hybrid --patch %s --array %s --overwrite --no-prewhiten --mask-version padded_v1 --nsims 3 --lmax %d \" --walltime 00:40:00 -t 80" % (region,array,lmax)
         os.system(cmd)


### PR DESCRIPTION
This adds support for simulations of the microwave sky as seen by Planck (lensed Gaussian + inhomogenous and anisotropic noise). Planck noise sims already exist in master, but this PR provides interfaces for the total cmb + noise. Foregrounds have not been explicitly handled, so I'm not sure what happens when you request them. I'm working on foregrounds (with help from Zack).