### PR TITLE
fixed (?) a pathname for the phi maps

### DIFF
--- a/actsims/lensingTools.py
+++ b/actsims/lensingTools.py
@@ -2,6 +2,7 @@ from flipper import *
 import pdb
 import scipy
 
+import numpy
 
 def lensMaps(phi,T_map, Q_map, U_map, TaylOrder = 5):#,iii,count): van Engelen commented out the last two args as they don't seem to be used in this routine.
     

--- a/actsims/signal.py
+++ b/actsims/signal.py
@@ -287,7 +287,7 @@ class SignalGen(object):
     def load_alm_phi(self, set_idx, sim_idx, cache=True, ret_alm=False):
         # note: beam is set to false
         print("loading alm phi")
-        phi_file = os.path.join(self.signal_path, 'fullskyPhi_alm_set%02d_%05d.fits' %(set_idx, sim_idx))
+        phi_file = os.path.join(self.signal_path, 'fullskyPhi_alm_%05d.fits' %(sim_idx))
         print("loading %s" %phi_file)
         alm_phi  = np.complex128(hp.fitsfunc.read_alm(phi_file, hdu = (1))) 
 


### PR DESCRIPTION
The phi a_lm's do not have a set number attached, so this code was crashing for me.  Getting rid of the set number made the routine work nicely.  (Maybe an earlier version of the sims had a set label attached to the phi maps)