### PR TITLE
v0.5 updates

### DIFF
--- a/actsims/util.py
+++ b/actsims/util.py
@@ -193,6 +193,7 @@ def config_from_yaml(filename):
 
 """
 I'll probably be moving these git info functions to a pipelining package later
+COPIED INTO PYFISHER
 """
 def pretty_info(info):
     name = info['package'] if info['package'] is not None else info['path']

--- a/bin/signalSims.py
+++ b/bin/signalSims.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import logging
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
@@ -12,9 +13,8 @@ from mpi4py import MPI
 import yaml
 from enlib import bench
 from pixell import aberration
-import logging
 from actsims import util as autil
-import os,sys
+import os,sys,json,shutil
 
 defaults = autil.config_from_yaml("../inputParams/defaults_lcmb.yaml")
 try:
@@ -27,92 +27,121 @@ except:
 
 import argparse
 # Parse command line
-parser = argparse.ArgumentParser(description='Generate lensed CMB.')
-parser.add_argument("--nsims",     type=int,  default=defaults['nsims'],help="Number of sims.")
-parser.add_argument("--start-index",     type=int,  default=defaults['start_index'],help="Start index.")
+parser = argparse.ArgumentParser(description='Generate lensed CMB.',
+                                 epilog='Example: python signalSims.py --skip-aberration --cmb-phi-sets [[0,0],[1,0]] --nsims [2000,500]')
+parser.add_argument("--nsims",     type=json.loads,  default=defaults['nsims'],help="List of number of sims for each cmb_phi_set.")
+parser.add_argument("--start-index",     type=json.loads,  default=defaults['start_index'],help="List of start indices for each cmb_phi_set.")
 parser.add_argument("--skip-aberration", action='store_true',help='Skip aberration.')
+parser.add_argument("--only-show-njobs", action='store_true',help='Do not simulate; just show total number of jobs.')
 parser.add_argument("--lmax",     type=int,  default=defaults['lmax'],help="Maxmimum multipole for lensing.")
 parser.add_argument("--lmax-write",     type=int,  default=defaults['lmax_write'],help="Maximum multipole to write.")
 parser.add_argument("--pix-size",     type=float,  default=defaults['pix_size'],help="Pixel width in arcminutes.")
-parser.add_argument("--cmb-sets",     type=int,  nargs='+', default=defaults['cmb_sets'],help="CMB sets.")
-parser.add_argument("--phi-sets",     type=int,  nargs='+', default=defaults['phi_sets'],help="phi sets.")
+parser.add_argument("--cmb-phi-sets",     type=json.loads, default=defaults['cmb_phi_sets'],help="List of cmb-phi-set index pairs. e.g. [[0,0],[1,0]]")
 parser.add_argument("--input-spec",     type=str,  default=defaults['input_spec_root'],help="Input spectrum root.")
 parser.add_argument("--output-dir",     type=str,  default=p['data_dir'],help="Output directory.")
 args = parser.parse_args()
 
 cmb_dir = args.output_dir
-logging.basicConfig(filename=f'{cmb_dir}/log.txt', level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s',filemode='w')
 
-comm,rank,my_tasks = autil.distribute(args.nsims)
+# Save args for later reference
+with open(f'{cmb_dir}/args.yml','w') as f:
+    f.write(yaml.dump(vars(args)))
+
+# Create a list of jobs and MPI distribute
+jobs = []
+assert len(args.nsims)==len(args.cmb_phi_sets)==len(args.start_index)
+for cpset,nsim,sindex in zip(args.cmb_phi_sets,args.nsims,args.start_index):
+    cmb_set,phi_set = cpset
+    for i in range(nsim):
+        jobs.append( (cmb_set,phi_set,i+sindex) )
+
+nsims = len(jobs)
+if args.only_show_njobs:
+    print(f"Number of jobs: {nsims}")
+    sys.exit()
+comm,rank,my_tasks = autil.distribute(nsims)
+
+# Start a logger
+if rank==0:
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+    logging.basicConfig(filename=f'{cmb_dir}/log.txt', level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s',filemode='w')
+
+# Initialize geometry
 shape, wcs = enmap.fullsky_geometry(args.pix_size*utils.arcmin)
-ps = powspec.read_camb_full_lens(args.input_spec + "_lenspotentialCls.dat")
 
+# Load theory file and save for later reference
+ps = powspec.read_camb_full_lens(args.input_spec + "_lenspotentialCls.dat")
+shutil.copyfile(args.input_spec + "_lenspotentialCls.dat",f'{cmb_dir}/lenspotentialCls.dat')
+#make phi totally uncorrelated with both T and E.  This is necessary due to the way that separate phi and CMB seeds were put forward in an update to the pixell library around mid-Nov 2018
+ps[0, 1:, :] = 0.
+ps[1:, 0, :] = 0.
+
+# Initialize aberrator
 if not(args.skip_aberration):
     with bench.mark("init ab"):
         ab = aberration.Aberrator(shape, wcs, modulation=None)
     if rank==0:
         logging.info(f'BENCH:\n{bench.stats}')
 
-#make phi totally uncorrelated with both T and E.  This is necessary due to the way that separate phi and CMB seeds were put forward in an update to the pixell library around mid-Nov 2018
-ps[0, 1:, :] = 0.
-ps[1:, 0, :] = 0.
-
+# Log package info
 if rank == 0:
     logging.info("Saving package info...")
     logging.info(autil.pretty_info(autil.get_info(path=os.path.realpath(__file__))))
     logging.info(autil.pretty_info(autil.get_info(package='pixell')))
 
 
+# Loop over tasks
+for j,task in enumerate(my_tasks):
 
-for cmb_set in args.cmb_sets:    
-    for phi_set in args.phi_sets:    
-        for task in my_tasks:
-            iii = task + args.start_index
-            logging.info(f'rank {rank} doing cmb_set {cmb_set}, task {iii} calling lensing.rand_map')
+    # Get CMB and Phi seeds
+    cmb_set,phi_set,iii = jobs[task]
+    cmb_seed = seedgen.get_cmb_seed(cmb_set, iii) 
+    phi_seed = seedgen.get_phi_seed(phi_set, iii)
+    logging.info(f'rank {rank}, task {task}, doing cmb_set {cmb_set}, phi_set {phi_set}, iteration {iii}')
 
-            phi_seed = seedgen.get_phi_seed(phi_set, iii)
-            cmb_seed = seedgen.get_cmb_seed(cmb_set, iii)
+    # Make lensed map
+    with bench.mark("lensing"):
+        l_tqu_map, = lensing.rand_map((3,)+shape, wcs, ps,
+                                      lmax=args.lmax,
+                                      output="l",
+                                      phi_seed = phi_seed,
+                                      seed = cmb_seed,
+                                      verbose = (True if rank==0 else False))
+    if rank==0: logging.info(f'BENCH:\n{bench.stats}')
 
-            with bench.mark("lensing"):
-                l_tqu_map, = lensing.rand_map((3,)+shape, wcs, ps,
-                                              lmax=args.lmax,
-                                              output="l",
-                                              phi_seed = phi_seed,
-                                              seed = cmb_seed,
-                                              verbose = (True if rank==0 else False))
+    map_list = [l_tqu_map]
+    map_name_list = ['fullskyLensedUnaberratedCMB']
+
+    if not(args.skip_aberration):
+
+        if rank==0:
+            logging.info('doing aberration')
+
+        #Note - we are aberrating and not modulating! The
+        #modulation is a frequency-dependent, so is done
+        #later.
+        with bench.mark("boost"):
+            l_tqu_map_aberrated = ab.aberrate(l_tqu_map)
+        if rank==0:
             logging.info(f'BENCH:\n{bench.stats}')
 
-            map_list = [l_tqu_map]
-            map_name_list = ['fullskyLensedUnaberratedCMB']
 
-            if not(args.skip_aberration):
-
-                if rank==0:
-                    logging.info('doing aberration')
-                    logging.info(f'rank {rank} doing cmb_set {cmb_set} task {iii} calling aberration.boost_map')
+        map_list += [l_tqu_map_aberrated]
+        map_name_list += ['fullskyLensedAberratedCMB']
 
 
-                #Note - we are aberrating and not modulating! The
-                #modulation is a frequency-dependent, so is done
-                #later.
-                with bench.mark("boost"):
-                    l_tqu_map_aberrated = ab.aberrate(l_tqu_map)
-                if rank==0:
-                    logging.info(f'BENCH:\n{bench.stats}')
+    for mi, mmm in enumerate(map_list):
+        if rank==0:
+            logging.info(f'curvedsky.map2alm for {map_name_list[mi]}')
+        alm = curvedsky.map2alm(mmm, lmax=args.lmax_write)
+        filename = cmb_dir + f"/{map_name_list[mi]}_alm_cmb_set_{cmb_set:02d}_phi_set_{phi_set:02d}_{iii:05d}.fits"
 
+        if rank==0:
+            logging.info(f'writing to disk, filename is {filename}')
 
-                map_list += [l_tqu_map_aberrated]
-                map_name_list += ['fullskyLensedAberratedCMB']
+        healpy.fitsfunc.write_alm(filename ,
+                                   np.complex64(alm), overwrite = True)
 
-
-            for mi, mmm in enumerate(map_list):
-                if rank==0:
-                    logging.info(f'{iii} calling curvedsky.map2alm for {map_name_list[mi]}')
-                alm = curvedsky.map2alm(mmm, lmax=args.lmax_write)
-                filename = cmb_dir + f"/{map_name_list[mi]}_alm_cmb_set_{cmb_set:02d}_phi_set_{phi_set:02d}_{iii:05d}.fits"
-
-                if rank==0:
-                    logging.info(f'writing to disk, filename is {filename}')
-
-                healpy.fitsfunc.write_alm(filename ,
-                                           np.complex64(alm), overwrite = True)
+    if rank==0:
+        logging.info(f'rank 0: {(j+1.)*100./len(my_tasks)} % done...')

--- a/inputParams/defaults_lcmb.yaml
+++ b/inputParams/defaults_lcmb.yaml
@@ -1,28 +1,28 @@
 input_spec_root: '../data/cosmo2017_10K_acc3'
 
+# These correspond to sets used for RDN0+MCMF+PS, MCN1 S=Sphi, MCN1 Sphi', MCN1 S'
+cmb_phi_sets: [[0,0],[1,1],[2,1],[2,2]]
+
+
 # DEBUG settings
 # lmax: 1000
 # lmax_write: 1000
 # pix_size: 10.0
+# nsims: [2,2,2,2]
 
 # SCIENCE settings
+# lmax: 10000
+# lmax_write: 10000
+# pix_size: 1.0
+# nsims: 2000,500,500,500
+
+# SCIENCE TEST settings
 lmax: 10000
 lmax_write: 10000
 pix_size: 1.0
+nsims: [24,8,8,8]
 
-cmb_sets: [0,1]
-phi_sets: [0,1]
-
-# This will do 0-1999
-nsims: 2000
-start_index: 0
-
-# e.g. This will do 0-499
-# nsims: 500
-# start_index: 0
-
-# e.g. This will do 500-999
-# nsims: 500
-# start_index: 500
+# This will do [0-1999,0-499,0-499,0-499]
+start_index: [0,0,0,0]
 
 


### PR DESCRIPTION
This changes the scheme for producing new v0.5 sims slightly, since we don't need the same number of correlated phi sims as we do for the main set. It also adds functions for retrieving the phi and unlensed CMB alms. A summary and some tests of the lower variance N1 are here: https://docs.google.com/presentation/d/1v-oo_E8l9pqQP3EDM74P0nUfT8-4N6FvtoRZj9umzZQ/edit?usp=sharing